### PR TITLE
Remove misleading URL for win2012r2

### DIFF
--- a/boxes/win2012r2x64-vagrant/Vagrantfile
+++ b/boxes/win2012r2x64-vagrant/Vagrantfile
@@ -6,11 +6,11 @@ Vagrant.configure("2") do |config|
   config.vm.box = "win2012r2x64"
 
   config.vm.provider :vmware_fusion do |v, override|
-    #override.vm.box_url = "https://googledrive.com/host/0B6J6sk4wHy07NmxkdmNma0xYb00/"
+    #override.vm.box_url = ENTER A URL TO A VALID VMWARE FUSION BASE BOX OF win2012r2
   end
 
   config.vm.provider :virtualbox do |v, override|
-    #override.vm.box_url = "https://googledrive.com/host/0B6J6sk4wHy07cVB5SE5CWVFPZzg/"
+    #override.vm.box_url = ENTER A URL TO A VALID VIRTUALBOX BASE BOX OF win2012r2
     override.vm.network :private_network, ip: "192.168.0.12"
   end
 


### PR DESCRIPTION
When trying to use this file I thought that the URL given might be one that will work for getting a win2012r2 image. I hadn't looked at any other vagrantfiles to notice that it was just a stock URL that wouldn't work for a 2012 box :(

This changes it to make it clearer to anyone reading that they will need to find their own basebox.
